### PR TITLE
Adding log level and error bubbling

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,10 +21,12 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('whitewashing_loggly');
 
         $rootNode->children()
-                    ->scalarNode('key')->isRequired()->end()
-                    ->scalarNode('port')->defaultValue(443)->end()
-                    ->scalarNode('host')->defaultValue('logs.loggly.com')->end()
-                ->end();
+                ->scalarNode('key')->isRequired()->end()
+                ->scalarNode('port')->defaultValue(443)->end()
+                ->scalarNode('host')->defaultValue('logs.loggly.com')->end()
+                ->scalarNode('level')->defaultValue(constant('Monolog\Logger::DEBUG'))->end()
+                ->booleanNode('bubble')->defaultValue(true)->end()
+            ->end();
 
         return $treeBuilder;
     }

--- a/DependencyInjection/WhitewashingLogglyExtension.php
+++ b/DependencyInjection/WhitewashingLogglyExtension.php
@@ -25,8 +25,13 @@ class WhitewashingLogglyExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        // Set the level to the correct integer value provided by Monoglog
+        $config['level'] = is_int($config['level']) ? $config['level'] : constant('Monolog\Logger::'.strtoupper($config['level']));
+
         $container->setParameter('whitewashing_loggly.loggly.key', $config['key']);
         $container->setParameter('whitewashing_loggly.loggly.host', $config['host']);
         $container->setParameter('whitewashing_loggly.loggly.port', $config['port']);
+        $container->setParameter('whitewashing_loggly.loggly.level', $config['level']);
+        $container->setParameter('whitewashing_loggly.loggly.bubble', $config['bubble']);
     }
 }

--- a/Monolog/Handler/LogglyHandler.php
+++ b/Monolog/Handler/LogglyHandler.php
@@ -43,11 +43,13 @@ class LogglyHandler extends AbstractProcessingHandler
      */
     private $fp;
 
-    public function __construct($key, $port = 443, $host = 'logs.loggly.com')
+    public function __construct($key, $port = 443, $host = 'logs.loggly.com', $level = Logger::DEBUG, $bubble = true)
     {
         $this->key = $key;
         $this->port = $port;
         $this->host = $host;
+
+        parent::__construct($level, $bubble);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ Configure Monolog
 Configure Loggly:
 
     whitewashing_loggly:
+        # Loggly input key
         key: abcdefg
-        host: logs.loggly.com
-        post: 443
 
+        # Loggly API host
+        host: logs.loggly.com
+
+        # Loggly API port (443 for HTTPS, 80 for HTTP)
+        port: 443
+
+        # Level to be logged (defaults to DEBUG)
+        level: DEBUG
+
+        bubble: true

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Deps
 
     [WhitewashingLogglyBundle]
         git=https://github.com/beberlei/WhitewashingLogglyBundle.git
-        target=/bundles/Whitewashing/Bundle/LogglyBundle
+        target=/bundles/Whitewashing/LogglyBundle
 
 Kernel
 
     $bundles = array(
         //..
-        new Whitewashing\Bundle\LogglyBundle\WhitewashingLogglyBundle(),
+        new Whitewashing\LogglyBundle\WhitewashingLogglyBundle(),
     );
 
 Autoload:
 
     $loader->registerNamespaces(array(
         //..
-        'Whitewashing\Bundle\LogglyBundle' => __DIR__.'/../vendor/bundles',
+        'Whitewashing\LogglyBundle' => __DIR__.'/../vendor/bundles',
     ));
 
 ## Configuration

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,6 +8,8 @@
         <parameter key="whitewashing_loggly.loggly.key"></parameter>
         <parameter key="whitewashing_loggly.loggly.port">443</parameter>
         <parameter key="whitewashing_loggly.loggly.host">logs.loggly.com</parameter>
+        <parameter key="whitewashing_loggly.loggly.level"></parameter>
+        <parameter key="whitewashing_loggly.loggly.bubble">true</parameter>
     </parameters>
 
     <services>
@@ -15,6 +17,8 @@
             <argument>%whitewashing_loggly.loggly.key%</argument>
             <argument>%whitewashing_loggly.loggly.port%</argument>
             <argument>%whitewashing_loggly.loggly.host%</argument>
+            <argument>%whitewashing_loggly.loggly.level%</argument>
+            <argument>%whitewashing_loggly.loggly.bubble%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Allows developers to set the level at which they want to log to Loggly.

Not using the Symfony2 handler to define at present, can't find any clear documentation from it, however this allows level setting within the service definition itself for now.
