### PR TITLE
Error with PSR-0 fileloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Deps
 
     [WhitewashingLogglyBundle]
         git=https://github.com/beberlei/WhitewashingLogglyBundle.git
-        target=/bundles/Whitewashing/LogglyBundle
+        target=/bundles/Whitewashing/Bundle/LogglyBundle
 
 Kernel
 
     $bundles = array(
         //..
-        new Whitewashing\LogglyBundle\WhitewashingLogglyBundle(),
+        new Whitewashing\Bundle\LogglyBundle\WhitewashingLogglyBundle(),
     );
 
 Autoload:
 
     $loader->registerNamespaces(array(
         //..
-        'Whitewashing\LogglyBundle' => __DIR__.'/../vendor/bundles',
+        'Whitewashing' => __DIR__.'/../vendor/bundles',
     ));
 
 ## Configuration


### PR DESCRIPTION
When you just follow the instructions in the readme, you get an error: "The autoloader expected class "Whitewashing\LogglyBundle\WhitewashingLogglyBundle" to be defined in file "[...]/vendor/bundles/Whitewashing/LogglyBundle/WhitewashingLogglyBundle.php". The file was found but the class was not in it, the class name or namespace probably has a typo."

This is cuased by the Bundle subnamespace, Whitewashing\Bundle...\* , this Bundle namespace is not used anywhere else, so there are some smaller adjustments needed, in the documentation, or in the namespaces.

Love,
