### PR TITLE
Modified the handler to support handleBatch() for better performance as a buffered handler

### DIFF
--- a/Monolog/Handler/LogglyHandler.php
+++ b/Monolog/Handler/LogglyHandler.php
@@ -93,8 +93,6 @@ class LogglyHandler extends AbstractProcessingHandler
 
         fwrite($fp, $request);
         fclose($fp);
-		
-		file_put_contents('/tmp/loggly-'.uniqid('',true),$message);
 
         return true;
     }

--- a/Monolog/Handler/LogglyHandler.php
+++ b/Monolog/Handler/LogglyHandler.php
@@ -46,10 +46,10 @@ class LogglyHandler extends AbstractProcessingHandler
 
         parent::__construct($level, $bubble);
     }
-		
-	/**
-	 * {@inheritdoc}
-	 */
+
+    /**
+     * {@inheritdoc}
+     */
     public function handleBatch(array $records)
     {
         $messages = array();
@@ -62,17 +62,18 @@ class LogglyHandler extends AbstractProcessingHandler
         }
 
         if (!empty($messages)) {
-			$this->send((string)$this->getFormatter()->formatBatch($messages), $messages);
+            $this->send((string)$this->getFormatter()->formatBatch($messages), $messages);
         }
     }
 
-	/**
-	 * {@inheritdoc}
-	 */
+    /**
+     * {@inheritdoc}
+     */
     protected function write(array $record)
     {
         $this->send((string) $record['formatted'], array($record));
     }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
In case that the LogglyHandler is "under" the buffer handler, each message is still sent individually to Loggly. By implementing handleBatch(), all messages are sent in one HTTP message.

Example configuration (works also without this modification):

``` yaml
monolog:
    handlers:
        buffer_to_loggly:
            type: buffer
            level: debug
            handler: send_to_loggly
        send_to_loggly:
            type: service
            id: whitewashing_loggly.monolog_handler 
```

More background available in my blog post, http://www.villescorner.com/2012/08/symfony2-logging-with-loggly-monolog.html
