### PR TITLE
Import Monolog\Logger namespace.

### DIFF
--- a/Monolog/Handler/LogglyHandler.php
+++ b/Monolog/Handler/LogglyHandler.php
@@ -16,6 +16,7 @@ namespace Whitewashing\Bundle\LogglyBundle\Monolog\Handler;
 use Whitewashing\Bundle\LogglyBundle\WhitewashingLogglyBundle;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Formatter\JsonFormatter;
+use Monolog\Logger;
 
 /**
  * A loggly log handler for Symfony. It uses the Loggly HTTP API to push


### PR DESCRIPTION
The `Monolog\Logger` class is referenced, but not imported. This pull request adds the missing namespace import. Without this namespace import I get the following error when attempting to instantiate the `LogglyHandler` class:

```
Fatal error: Class 'Whitewashing\Bundle\LogglyBundle\Monolog\Handler\Logger' not found…
```
